### PR TITLE
LAB05: DALL-E is available only in EastUS now

### DIFF
--- a/Instructions/Labs/05-generate-images.md
+++ b/Instructions/Labs/05-generate-images.md
@@ -24,7 +24,7 @@ Before you can use Azure OpenAI models, you must provision an Azure OpenAI resou
 2. Create an **Azure OpenAI** resource with the following settings:
     - **Subscription**: An Azure subscription that has been approved for access to the Azure OpenAI service.
     - **Resource group**: Create a new resource group with a name of your choice.
-    - **Region**: Choose any available region.
+    - **Region**: Choose **EastUS** as region
     - **Name**: A unique name of your choice.
     - **Pricing tier**: Standard S0
 3. Wait for deployment to complete. Then go to the deployed Azure OpenAI resource in the Azure portal.


### PR DESCRIPTION
# Module: 04
## Lab/Demo: 05

Fixes # .

Changes proposed in this pull request:
During the creation of the Azure OpenAI resources (exercise "Provisioning an Azure OpenAI resource" - step 02), the instructions leave to the student the choice of the region but DELL-E now is only in EastUS (as mentioned here https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models#dall-e-models-preview)