### PR TITLE
LAB01: Some UI changes

### DIFF
--- a/Instructions/Labs/01-get-started-azure-openai.md
+++ b/Instructions/Labs/01-get-started-azure-openai.md
@@ -41,6 +41,8 @@ Azure OpenAI provides a web-based portal named **Azure OpenAI Studio**, that you
 
 > **Note**: Azure OpenAI includes multiple models, each optimized for a different balance of capabilities and performance. In this exercise, you'll use the **GPT-35-Turbo** model, which is a good general model for summarizing and generating natural language and code. For more information about the available models in Azure OpenAI, see [Models](https://learn.microsoft.com/azure/cognitive-services/openai/concepts/models) in the Azure OpenAI documentation.
 
+> **Note**: In some regions, the new model deployment interface doesn't show the **Model version** option. In this case, don't worry and continue without setting the option.
+
 ## Explore a model in the Completions playground
 
 *Playgrounds* are useful interfaces in Azure OpenAI Studio that you can use to experiment with your deployed models without needing to develop your own client application.

--- a/Instructions/Labs/01-get-started-azure-openai.md
+++ b/Instructions/Labs/01-get-started-azure-openai.md
@@ -88,7 +88,7 @@ You can use the prompt and parameters to maximize the likelihood of generating t
 
 1. In the **Parameters** pane, set the following parameter values:
     - **Temperature**: 0
-    - **Max length (tokens)**: 500
+    - **Max response**: 500
 
 2. Submit the following message
 

--- a/Instructions/Labs/02-natural-language-azure-openai.md
+++ b/Instructions/Labs/02-natural-language-azure-openai.md
@@ -42,6 +42,8 @@ To use the Azure OpenAI API, you must first deploy a model to use through the **
 
 > **Note**: Each Azure OpenAI model is optimized for a different balance of capabilities and performance. We'll use the **3.5 Turbo** model series in the **GPT-3** model family in this exercise, which is highly capable for language understanding. This exercise only uses a single model, however deployment and usage of other models you deploy will work in the same way.
 
+> **Note**: In some regions, the new model deployment interface doesn't show the **Model version** option. In this case, don't worry and continue without setting the option
+
 ## Set up an application in Cloud Shell
 
 To show how to integrate with an Azure OpenAI model, we'll use a short command-line application that runs in Cloud Shell on Azure. Open up a new browser tab to work with Cloud Shell.

--- a/Instructions/Labs/03-prompt-engineering.md
+++ b/Instructions/Labs/03-prompt-engineering.md
@@ -46,6 +46,8 @@ To use the Azure OpenAI API, you must first deploy a model to use through the **
 
 > **Note**: Each Azure OpenAI model is optimized for a different balance of capabilities and performance. We'll use the **3.5 Turbo** model series in the **GPT-3** model family in this exercise, which is highly capable for language understanding. This exercise only uses a single model, however deployment and usage of other models you deploy will work in the same way.
 
+> **Note**: In some regions, the new model deployment interface doesn't show the **Model version** option. In this case, don't worry and continue without setting the option
+
 ## Apply prompt engineering in chat playground
 
 Before using your app, examine how prompt engineering improves the model response in the playground. In this first example, imagine you are trying to write a python app of animals with fun names.

--- a/Instructions/Labs/04-code-generation.md
+++ b/Instructions/Labs/04-code-generation.md
@@ -42,6 +42,8 @@ To use the Azure OpenAI API for code generation, you must first deploy a model t
 
 > **Note**: Each Azure OpenAI model is optimized for a different balance of capabilities and performance. We'll use the **3.5 Turbo** model series in the **GPT-3** model family in this exercise, which is highly capable for both language and code understanding.
 
+> **Note**: In some regions, the new model deployment interface doesn't show the **Model version** option. In this case, don't worry and continue without setting the option
+
 ## Generate code in chat playground
 
 Before using in your app, examine how Azure OpenAI can generate and explain code in the chat playground.

--- a/Instructions/Labs/05-generate-images.md
+++ b/Instructions/Labs/05-generate-images.md
@@ -24,7 +24,7 @@ Before you can use Azure OpenAI models, you must provision an Azure OpenAI resou
 2. Create an **Azure OpenAI** resource with the following settings:
     - **Subscription**: An Azure subscription that has been approved for access to the Azure OpenAI service.
     - **Resource group**: Create a new resource group with a name of your choice.
-    - **Region**: Choose any available region.
+    - **Region**: Choose **EastUS** as region
     - **Name**: A unique name of your choice.
     - **Pricing tier**: Standard S0
 3. Wait for deployment to complete. Then go to the deployed Azure OpenAI resource in the Azure portal.

--- a/Instructions/Labs/06-use-own-data.md
+++ b/Instructions/Labs/06-use-own-data.md
@@ -39,6 +39,8 @@ To chat with the Azure OpenAI, you must first deploy a model to use through the 
     - **Model version**: *Use the default version*
     - **Deployment name**: text-turbo
 
+> **Note**: In some regions, the new model deployment interface doesn't show the **Model version** option. In this case, don't worry and continue without setting the option
+
 ## Observe normal chat behavior without adding your own data
 
 Before connecting Azure OpenAI to your data, first observe how the base model responds to queries without any grounding data.


### PR DESCRIPTION
# Module: 02
## Lab/Demo: 01

Changes proposed in this pull request:
- The Azure OpenAI Studio label for the max token seems to be changed in Max response:

![image](https://github.com/MicrosoftLearning/mslearn-openai/assets/9560142/06a5dd2b-adaf-4296-8a7b-b3089a85eed9)

- When you open the new model interface in the Azure OpenAI Studio, not all the regions have the option for Model version Some regions (the next figure shows the UI for an OpenAI Studio in a West Europe instance)

![image](https://github.com/MicrosoftLearning/mslearn-openai/assets/9560142/c1bf2dda-9aca-42ad-ae73-67a1d4d5d19e)


I add a note to tell the student to go ahead without setting the options. Alternatively, we need to suggest the right region in the OpenAI service creation settings. 
I add this note in all the other lab with the same instructions.