### PR TITLE
Use version `1.0.0-beta.12` of `Azure.AI.OpenAI` for Lab 02

### DIFF
--- a/Instructions/Exercises/02-natural-language-azure-openai.md
+++ b/Instructions/Exercises/02-natural-language-azure-openai.md
@@ -114,8 +114,8 @@ Now you're ready to use the Azure OpenAI SDK to consume your deployed model.
    {
         Messages =
         {
-            new ChatMessage(ChatRole.System, "You are a helpful assistant."),
-            new ChatMessage(ChatRole.User, "Summarize the following text in 20 words or less:\n" + text),
+            new ChatRequestSystemMessage("You are a helpful assistant."),
+            new ChatRequestUserMessage("Summarize the following text in 20 words or less:\n" + text),
         },
         MaxTokens = 120,
         Temperature = 0.7f,

--- a/Labfiles/02-nlp-azure-openai/CSharp/CSharp.csproj
+++ b/Labfiles/02-nlp-azure-openai/CSharp/CSharp.csproj
@@ -19,4 +19,11 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="..\text-files\*.*">
+      <Link>%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  
 </Project>

--- a/Labfiles/02-nlp-azure-openai/CSharp/CSharp.csproj
+++ b/Labfiles/02-nlp-azure-openai/CSharp/CSharp.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.AI.OpenAI" Version="1.0.0-beta.12" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
   </ItemGroup>

--- a/Labfiles/02-nlp-azure-openai/CSharp/Program.cs
+++ b/Labfiles/02-nlp-azure-openai/CSharp/Program.cs
@@ -17,7 +17,7 @@ string? oaiKey = config["AzureOAIKey"];
 string? oaiModelName = config["AzureOAIModelName"];
 
 // Read sample text file into a string
-string textToSummarize = System.IO.File.ReadAllText(@"../text-files/sample-text.txt");
+string textToSummarize = System.IO.File.ReadAllText(@"sample-text.txt");
 
 // Generate summary from Azure OpenAI
 GetSummaryFromOpenAI(textToSummarize);

--- a/Labfiles/02-nlp-azure-openai/CSharp/Program.cs
+++ b/Labfiles/02-nlp-azure-openai/CSharp/Program.cs
@@ -1,9 +1,7 @@
 ﻿// Implicit using statements are included
-using System.Text;
-using System.Text.Json;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Configuration.Json;
 using Azure;
+using Azure.AI.OpenAI;
 
 // Add Azure OpenAI package
 
@@ -17,12 +15,12 @@ string? oaiKey = config["AzureOAIKey"];
 string? oaiModelName = config["AzureOAIModelName"];
 
 // Read sample text file into a string
-string textToSummarize = System.IO.File.ReadAllText(@"sample-text.txt");
+string textToSummarize = File.ReadAllText(@"sample-text.txt");
 
 // Generate summary from Azure OpenAI
-GetSummaryFromOpenAI(textToSummarize);
+GetSummaryFromOpenAi(textToSummarize);
     
-void GetSummaryFromOpenAI(string text)  
+void GetSummaryFromOpenAi(string text)  
 {   
     Console.WriteLine("\nSending request for summary to Azure OpenAI endpoint...\n\n");
 


### PR DESCRIPTION
# Module: 00
## Lab/Demo: 02

Changes proposed in this pull request:
- Use version `1.0.0-beta.12` of `Azure.AI.OpenAI` for Lab 02
- Copy and the sample text file automatically
- Remove redundant code
- Comply with Microsoft set standards for method naming