### PR TITLE
Update 06-use-own-data.md

### DIFF
--- a/Instructions/Exercises/06-use-own-data.md
+++ b/Instructions/Exercises/06-use-own-data.md
@@ -43,7 +43,7 @@ Azure OpenAI provides a web-based portal named **Azure OpenAI Studio**, that you
 2. In Azure OpenAI Studio, on the **Deployments** page, view your existing model deployments. If you don't already have one, create a new deployment of the **gpt-35-turbo-16k** model with the following settings:
     - **Model**: gpt-35-turbo-16k *(must be this model to to use the features in this exercise)*
     - **Model version**: Auto-update to default
-    - **Deployment name**: *A unique name of your choice*
+    - **Deployment name**: *A unique name of your choice* (make a note of this name, you will use this name again later in this lab)
     - **Advanced options**
         - **Content filter**: Default
         - **Tokens per minute rate limit**: 5K\*


### PR DESCRIPTION
I had some students typing in the name of the model not the deployment here: So they were using gpt-35-turbo-16k and not the name they typed here

# Module: 06
## Lab/Demo: 06

Fixes # .

Changes proposed in this pull request:

-
-
-