### PR TITLE
LAB 02 : Add note for VSCode trust and fix two variable errors in C# and Python code

### DIFF
--- a/Instructions/Exercises/02-natural-language-azure-openai.md
+++ b/Instructions/Exercises/02-natural-language-azure-openai.md
@@ -125,7 +125,7 @@ Now you're ready to use the Azure OpenAI SDK to consume your deployed model.
         },
         MaxTokens = 120,
         Temperature = 0.7f,
-        DeploymentName = oaiModelName
+        DeploymentName = oaiDeploymentName
    };
 
    // Send request to Azure OpenAI model

--- a/Instructions/Exercises/02-natural-language-azure-openai.md
+++ b/Instructions/Exercises/02-natural-language-azure-openai.md
@@ -147,7 +147,7 @@ Now you're ready to use the Azure OpenAI SDK to consume your deployed model.
 
    # Send request to Azure OpenAI model
    response = client.chat.completions.create(
-       model=azure_oai_model,
+       model=azure_oai_deployment,
        temperature=0.7,
        max_tokens=120,
        messages=[

--- a/Instructions/Exercises/02-natural-language-azure-openai.md
+++ b/Instructions/Exercises/02-natural-language-azure-openai.md
@@ -51,6 +51,9 @@ You'll develop your Azure OpenAI app using Visual Studio Code. The code files fo
 1. Start Visual Studio Code.
 2. Open the palette (SHIFT+CTRL+P) and run a **Git: Clone** command to clone the `https://github.com/MicrosoftLearning/mslearn-openai` repository to a local folder (it doesn't matter which folder).
 3. When the repository has been cloned, open the folder in Visual Studio Code.
+
+    > **Note**: If Visual Studio Code shows you a pop-up message to prompt you to trust the code you are opening, click on **Yes, I trust the authors** option in the pop-up.
+
 4. Wait while additional files are installed to support the C# code projects in the repo.
 
     > **Note**: If you are prompted to add required assets to build and debug, select **Not Now**.


### PR DESCRIPTION
# Module: 02
## Lab/Demo: 02

Fixes #41 

Changes proposed in this pull request:

- I added a note regarding the pop-up that visual studio code shows to confirm the trust of the newly cloned code
- In the C# and Python code reported in the instructions, the name of the variable containing the name of the model to be used is incorrect. I corrected the name. (Fixed Issue #41 )