### PR TITLE
Labs 02-03-04-05-06: Add note to manage Trust code pop-up in VS Code and Fix error in C# code

### DIFF
--- a/Instructions/Exercises/02-natural-language-azure-openai.md
+++ b/Instructions/Exercises/02-natural-language-azure-openai.md
@@ -125,7 +125,7 @@ Now you're ready to use the Azure OpenAI SDK to consume your deployed model.
         },
         MaxTokens = 120,
         Temperature = 0.7f,
-        DeploymentName = oaiModelName
+        DeploymentName = oaiDeploymentName
    };
 
    // Send request to Azure OpenAI model

--- a/Instructions/Exercises/02-natural-language-azure-openai.md
+++ b/Instructions/Exercises/02-natural-language-azure-openai.md
@@ -147,7 +147,7 @@ Now you're ready to use the Azure OpenAI SDK to consume your deployed model.
 
    # Send request to Azure OpenAI model
    response = client.chat.completions.create(
-       model=azure_oai_model,
+       model=azure_oai_deployment,
        temperature=0.7,
        max_tokens=120,
        messages=[

--- a/Instructions/Exercises/02-natural-language-azure-openai.md
+++ b/Instructions/Exercises/02-natural-language-azure-openai.md
@@ -51,6 +51,9 @@ You'll develop your Azure OpenAI app using Visual Studio Code. The code files fo
 1. Start Visual Studio Code.
 2. Open the palette (SHIFT+CTRL+P) and run a **Git: Clone** command to clone the `https://github.com/MicrosoftLearning/mslearn-openai` repository to a local folder (it doesn't matter which folder).
 3. When the repository has been cloned, open the folder in Visual Studio Code.
+
+    > **Note**: If Visual Studio Code shows you a pop-up message to prompt you to trust the code you are opening, click on **Yes, I trust the authors** option in the pop-up.
+
 4. Wait while additional files are installed to support the C# code projects in the repo.
 
     > **Note**: If you are prompted to add required assets to build and debug, select **Not Now**.

--- a/Instructions/Exercises/03-prompt-engineering.md
+++ b/Instructions/Exercises/03-prompt-engineering.md
@@ -165,6 +165,9 @@ Now let's explore the use of prompt engineering in an app that uses the Azure Op
 1. Start Visual Studio Code.
 2. Open the palette (SHIFT+CTRL+P) and run a **Git: Clone** command to clone the `https://github.com/MicrosoftLearning/mslearn-openai` repository to a local folder (it doesn't matter which folder).
 3. When the repository has been cloned, open the folder in Visual Studio Code.
+
+    > **Note**: If Visual Studio Code shows you a pop-up message to prompt you to trust the code you are opening, click on **Yes, I trust the authors** option in the pop-up.
+
 4. Wait while additional files are installed to support the C# code projects in the repo.
 
     > **Note**: If you are prompted to add required assets to build and debug, select **Not Now**.

--- a/Instructions/Exercises/03-prompt-engineering.md
+++ b/Instructions/Exercises/03-prompt-engineering.md
@@ -256,7 +256,7 @@ Now you're ready to use the Azure OpenAI SDK to consume your deployed model.
         },
         Temperature = 0.7f,
         MaxTokens = 800,
-        DeploymentName = oaiModelName
+        DeploymentName = oaiDeploymentName
     };
     
     // Get response from Azure OpenAI

--- a/Instructions/Exercises/04-code-generation.md
+++ b/Instructions/Exercises/04-code-generation.md
@@ -200,7 +200,7 @@ Now you're ready to use the Azure OpenAI SDK to consume your deployed model.
         },
         Temperature = 0.7f,
         MaxTokens = 1000,
-        DeploymentName = oaiModelName
+        DeploymentName = oaiDeploymentName
     };
 
     // Get response from Azure OpenAI

--- a/Instructions/Exercises/04-code-generation.md
+++ b/Instructions/Exercises/04-code-generation.md
@@ -109,6 +109,9 @@ Now let's explore how you could build a custom app that uses Azure OpenAI servic
 1. Start Visual Studio Code.
 2. Open the palette (SHIFT+CTRL+P) and run a **Git: Clone** command to clone the `https://github.com/MicrosoftLearning/mslearn-openai` repository to a local folder (it doesn't matter which folder).
 3. When the repository has been cloned, open the folder in Visual Studio Code.
+
+    > **Note**: If Visual Studio Code shows you a pop-up message to prompt you to trust the code you are opening, click on **Yes, I trust the authors** option in the pop-up.
+
 4. Wait while additional files are installed to support the C# code projects in the repo.
 
     > **Note**: If you are prompted to add required assets to build and debug, select **Not Now**.

--- a/Instructions/Exercises/05-generate-images.md
+++ b/Instructions/Exercises/05-generate-images.md
@@ -52,6 +52,9 @@ Now let's explore how you could build a custom app that uses Azure OpenAI servic
 1. Start Visual Studio Code.
 2. Open the palette (SHIFT+CTRL+P) and run a **Git: Clone** command to clone the `https://github.com/MicrosoftLearning/mslearn-openai` repository to a local folder (it doesn't matter which folder).
 3. When the repository has been cloned, open the folder in Visual Studio Code.
+
+    > **Note**: If Visual Studio Code shows you a pop-up message to prompt you to trust the code you are opening, click on **Yes, I trust the authors** option in the pop-up.
+
 4. Wait while additional files are installed to support the C# code projects in the repo.
 
     > **Note**: If you are prompted to add required assets to build and debug, select **Not Now**.

--- a/Instructions/Exercises/06-use-own-data.md
+++ b/Instructions/Exercises/06-use-own-data.md
@@ -146,6 +146,9 @@ Now let's explore the use of your own data in an app that uses the Azure OpenAI 
 1. Start Visual Studio Code.
 2. Open the palette (SHIFT+CTRL+P) and run a **Git: Clone** command to clone the `https://github.com/MicrosoftLearning/mslearn-openai` repository to a local folder (it doesn't matter which folder).
 3. When the repository has been cloned, open the folder in Visual Studio Code.
+
+    > **Note**: If Visual Studio Code shows you a pop-up message to prompt you to trust the code you are opening, click on **Yes, I trust the authors** option in the pop-up.
+
 4. Wait while additional files are installed to support the C# code projects in the repo.
 
     > **Note**: If you are prompted to add required assets to build and debug, select **Not Now**.


### PR DESCRIPTION
# Module: 02-03-04-05-06
## Lab/Demo: 02-03-04-05-06

Fixes #41 

Changes proposed in this pull request:
- I added a note regarding the pop-up that visual studio code shows to confirm the trust of the newly cloned code
- In the C# code (and also in Python code for the lab 02 reported in issue #41) in the instructions, the name of the variable containing the name of the model to be used is incorrect. I set the right name.