### PR TITLE
fix typo in Exercise 1 instructions

### DIFF
--- a/Instructions/Exercises/01-get-started-azure-openai.md
+++ b/Instructions/Exercises/01-get-started-azure-openai.md
@@ -136,7 +136,7 @@ You've explored how the system message, examples, and prompts can help refine th
 1. In the **Chat session** section, use the **Clear chat** button to reset the chat session again, and then re-enter the same query as before (`Create an advertisement for a cleaning sponge`) and review the response. This time, the response may not be quite so creative.
 1. Use the **Clear chat** button to reset the chat session one more time, and then re-enter the same query as before (`Create an advertisement for a cleaning sponge`) and review the response; which should be very similar (if not identical) to the previous response.
 
-    The **Temperature** parameter controls the degree to which the model can be creative in its generation of a response. A low value results in a consistent response with little random variation, while a high value encourages the model to add creative elements its output; which may affect the accuracy and realism of the reeponse.
+    The **Temperature** parameter controls the degree to which the model can be creative in its generation of a response. A low value results in a consistent response with little random variation, while a high value encourages the model to add creative elements its output; which may affect the accuracy and realism of the response.
 
 ## Deploy your model to a web app
 


### PR DESCRIPTION
# Module: 01
## Lab/Demo: 01

Fixes # .

Changes proposed in this pull request:

- "reeponse" -> "response"
-
-