### PR TITLE
fix typo in Exercise 6 instructions

### DIFF
--- a/Instructions/Exercises/06-use-own-data.md
+++ b/Instructions/Exercises/06-use-own-data.md
@@ -76,7 +76,7 @@ Before connecting Azure OpenAI to your data, let's first observe how the base mo
 
 ## Connect your data in the chat playground
 
-Bow you'll add some data for a fictional travel agent company named *Margie's Travel*. Then you'll see how the Azure openAI model responds when using the brochures from Margie's Travel as grounding data.
+Now you'll add some data for a fictional travel agent company named *Margie's Travel*. Then you'll see how the Azure openAI model responds when using the brochures from Margie's Travel as grounding data.
 
 1. In a new browser tab, download an archive of brochure data from `https://aka.ms/own-data-brochures`. Extract the brochures to a folder on your PC.
 1. In Azure OpenAI Studio, in the **Chat** playground, in the **Assistant setup** section, select **Add your data**.


### PR DESCRIPTION
"Bow" -> "Now"

# Module: 06
## Lab/Demo: 06

Fixes # .

Changes proposed in this pull request:

- "Bow" -> "Now"