### PR TITLE
Update python pip from version 1.13.3 to version 1.55.3

### DIFF
--- a/Instructions/Exercises/03-prompt-engineering.md
+++ b/Instructions/Exercises/03-prompt-engineering.md
@@ -200,7 +200,7 @@ Applications for both C# and Python have been provided, and both apps feature th
     **Python**:
 
     ```
-    pip install openai==1.13.3
+    pip install openai==1.55.3
     ```
 
 3. In the **Explorer** pane, in the **CSharp** or **Python** folder, open the configuration file for your preferred language

--- a/Instructions/Exercises/04-code-generation.md
+++ b/Instructions/Exercises/04-code-generation.md
@@ -144,7 +144,7 @@ Applications for both C# and Python have been provided, as well as a sample text
     **Python**:
 
     ```
-    pip install openai==1.13.3
+    pip install openai==1.55.3
     ```
 
 3. In the **Explorer** pane, in the **CSharp** or **Python** folder, open the configuration file for your preferred language

--- a/Instructions/Exercises/06-use-own-data.md
+++ b/Instructions/Exercises/06-use-own-data.md
@@ -151,7 +151,7 @@ Applications for both C# and Python have been provided, and both apps feature th
     **Python**:
 
     ```
-    pip install openai==1.13.3
+    pip install openai==1.55.3
     ```
 
 3. In the **Explorer** pane, in the **CSharp** or **Python** folder, open the configuration file for your preferred language


### PR DESCRIPTION


Fixes #99 

Changes proposed in this pull request:

error when using  python openai library version 1.13.3
=> error shows Client.init() got an expected keyword argment 'proxies'

chagne to 1.55.3 can solve this error.